### PR TITLE
Modify or to || and Exception to RuntimeError

### DIFF
--- a/lib/mandrill.rb
+++ b/lib/mandrill.rb
@@ -85,7 +85,7 @@ module Mandrill
 
             begin
                 error_info = JSON.parse(body)
-                if error_info['status'] != 'error' or not error_info['name']
+                if error_info['status'] != 'error' || not error_info['name']
                     raise Error, "We received an unexpected error: #{body}"
                 end
                 if error_map[error_info['name']]

--- a/lib/mandrill/errors.rb
+++ b/lib/mandrill/errors.rb
@@ -1,5 +1,5 @@
 module Mandrill
-    class Error < Exception
+    class Error < RuntimeError
     end
     class ValidationError < Error
     end


### PR DESCRIPTION
# 1. Altered or with || 
Given this line:
```ruby
if error_info['status'] != 'error' or not error_info['name']
```
We want to give higher precedence  to `error_info['status'] != 'error'` and revert to check for `not error_info['name']` if and only if the first check fails. This will help improve the speed of our program as well!

# 2. Altered Exception to RuntimeError
Given the code snippet:
```ruby
 class Error < Exception
```
Lint/RescueException looks for misuse of Exception in a rescue statement, and dutifully suggests to rescue from StandardError which is Ruby's default for rescue. Since there is a high chance a similar mistake when declaring an exception class is being made, the suggested fix may lead to the exception never being caught.

As an example, picture someone following Rubocop's advice and fixes this:

```ruby
class FooError < Exception; end

begin
  raise FooError
rescue Exception
  puts 'rescued'
end
```
into this:
```ruby
class FooError < Exception; end

begin
  raise FooError
rescue StandardError
  puts 'rescued'
end
```
when he should have been doing this instead:
```ruby
class FooError < RuntimeError; end

begin
  raise FooError
rescue StandardError
  puts 'rescued'
end
```
As a consequence it is quite interesting to lint for custom exceptions that may mistakenly inherit from Exception instead of either StandardError or RuntimeError, the latter being preferred since it's the default for fail/raise (perusing the symmetry with rescue being prodded into Ruby's default behaviour).

Expected behavior:
```ruby
# no problem
class FooError; end

# no problem, if RuntimeError is preferred (default)
class FooError < RuntimeError; end

# no problem, if StandardError is preferred (alternate `EnforcedStyle`)
class FooError < StandardError; end

# this is a problem
class FooError < Exception; end

# should it be legit, it should be explicitly ignored by a directive along with due documentation
class ReallyAnException < Exception; end # rubocop:disable Lint/InheritException
```
Conclusion:
Avoid inheriting from the Exception class. Perhaps you meant to inherit from RuntimeError

